### PR TITLE
Update workflow to skip RunPreCommit on PR drafts

### DIFF
--- a/Templates/Per Tenant Extension/.github/workflows/RunPreCommit.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/RunPreCommit.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
     pre-commit:
+        name: Run Pre-Commit
+        if: github.event.pull_request.draft == false
         runs-on: ubuntu-latest
 
         steps:


### PR DESCRIPTION
This pull request updates the workflow to skip the RunPreCommit step when the pull request is in draft mode. This helps to improve the efficiency of the workflow by avoiding unnecessary checks on draft pull requests.