### PR TITLE
Add "runs-on" check to allow updating runs-on on all workflows

### DIFF
--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -200,7 +200,19 @@ jobs:
           Write-Host "repoName='$repoName'"
           Write-Host "Repo URL: https://github.com/${{ needs.Check.outputs.githubowner }}/$repoName"
 
-      - name: Run test
+      - name: Run test on Linux
+        run: |
+          try {
+            . (Join-Path "." "e2eTests/scenarios/${{ matrix.scenario }}/runtest.ps1") -github -linux -githubOwner '${{ needs.Check.outputs.githubowner }}' -repoName ${{ steps.calculateParams.outputs.repoName }} -token '${{ Secrets.E2EPAT }}' -pteTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}' -appSourceTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.appSourceAppRepo }}' -adminCenterApiToken '${{ Secrets.adminCenterApiCredentials }}'
+          }
+          catch {
+            Write-Host $_.Exception.Message
+            Write-Host $_.ScriptStackTrace
+            Write-Host "::Error::$($_.Exception.Message)"
+            $host.SetShouldExit(1)
+          }
+
+      - name: Run test on Windows
         run: |
           try {
             . (Join-Path "." "e2eTests/scenarios/${{ matrix.scenario }}/runtest.ps1") -github -githubOwner '${{ needs.Check.outputs.githubowner }}' -repoName ${{ steps.calculateParams.outputs.repoName }} -token '${{ Secrets.E2EPAT }}' -pteTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}' -appSourceTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.appSourceAppRepo }}' -adminCenterApiToken '${{ Secrets.adminCenterApiCredentials }}'

--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -181,7 +181,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "scenarios=$scenariosJson"
           Write-Host "scenarios=$scenariosJson"
 
-  Scenario:
+  ScenariosOnWindows:
     runs-on: [ windows-latest ]
     needs: [ Check, SetupRepositories, Analyze ]
     if: github.event.inputs.runScenarios == 'true'
@@ -198,13 +198,12 @@ jobs:
           $reponame = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName())
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "repoName=$repoName"
           Write-Host "repoName=$repoName"
-          Write-Host "Repo URL (Windows): https://github.com/${{ needs.Check.outputs.githubowner }}/$($repoName)w"
-          Write-Host "Repo URL (Linux): https://github.com/${{ needs.Check.outputs.githubowner }}/$($repoName)l"
+          Write-Host "Repo URL: https://github.com/${{ needs.Check.outputs.githubowner }}/$repoName"
 
-      - name: Run test on Linux
+      - name: Run test on Windows
         run: |
           try {
-            . (Join-Path "." "e2eTests/scenarios/${{ matrix.scenario }}/runtest.ps1") -github -linux -githubOwner '${{ needs.Check.outputs.githubowner }}' -repoName '${{ steps.calculateParams.outputs.repoName }}l' -token '${{ Secrets.E2EPAT }}' -pteTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}' -appSourceTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.appSourceAppRepo }}' -adminCenterApiToken '${{ Secrets.adminCenterApiCredentials }}'
+            . (Join-Path "." "e2eTests/scenarios/${{ matrix.scenario }}/runtest.ps1") -github -githubOwner '${{ needs.Check.outputs.githubowner }}' -repoName '${{ steps.calculateParams.outputs.repoName }}' -token '${{ Secrets.E2EPAT }}' -pteTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}' -appSourceTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.appSourceAppRepo }}' -adminCenterApiToken '${{ Secrets.adminCenterApiCredentials }}'
           }
           catch {
             Write-Host $_.Exception.Message
@@ -213,10 +212,29 @@ jobs:
             $host.SetShouldExit(1)
           }
 
-      - name: Run test on Windows
+  ScenariosOnLinux:
+    runs-on: [ windows-latest ]
+    needs: [ Check, SetupRepositories, Analyze ]
+    if: github.event.inputs.runScenarios == 'true'
+    strategy: ${{ fromJson(needs.Analyze.outputs.scenarios) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Calculate parameters
+        id: calculateParams
+        run: |
+          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
+          $reponame = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName())
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "repoName=$repoName"
+          Write-Host "repoName=$repoName"
+          Write-Host "Repo URL: https://github.com/${{ needs.Check.outputs.githubowner }}/$repoName"
+
+      - name: Run tests
         run: |
           try {
-            . (Join-Path "." "e2eTests/scenarios/${{ matrix.scenario }}/runtest.ps1") -github -githubOwner '${{ needs.Check.outputs.githubowner }}' -repoName '${{ steps.calculateParams.outputs.repoName }}w' -token '${{ Secrets.E2EPAT }}' -pteTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}' -appSourceTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.appSourceAppRepo }}' -adminCenterApiToken '${{ Secrets.adminCenterApiCredentials }}'
+            . (Join-Path "." "e2eTests/scenarios/${{ matrix.scenario }}/runtest.ps1") -github -linux -githubOwner '${{ needs.Check.outputs.githubowner }}' -repoName '${{ steps.calculateParams.outputs.repoName }}' -token '${{ Secrets.E2EPAT }}' -pteTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}' -appSourceTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.appSourceAppRepo }}' -adminCenterApiToken '${{ Secrets.adminCenterApiCredentials }}'
           }
           catch {
             Write-Host $_.Exception.Message
@@ -355,7 +373,7 @@ jobs:
 
   RemoveRepositories:
     runs-on: [ ubuntu-latest ]
-    needs: [ Check, SetupRepositories, TestAlGoPublic, TestAlGoPrivate, TestAlGoUpgrade, Scenario ]
+    needs: [ Check, SetupRepositories, TestAlGoPublic, TestAlGoPrivate, TestAlGoUpgrade, ScenariosOnWindows, ScenariosOnLinux ]
     if: always() && (!Cancelled()) && (needs.SetupRepositories.result == 'Success') && (needs.TestAlGoPublic.result == 'Success' || needs.TestAlGoPublic.result == 'Skipped') && (needs.TestAlGoPrivate.result == 'Success' || needs.TestAlGoPrivate.result == 'Skipped') && (needs.TestAlGoUpgrade.result == 'Success' || needs.TestAlGoUpgrade.result == 'Skipped') && (needs.Scenario.result == 'Success' || needs.Scenario.result == 'Skipped')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -198,12 +198,13 @@ jobs:
           $reponame = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName())
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "repoName='$repoName'"
           Write-Host "repoName='$repoName'"
-          Write-Host "Repo URL: https://github.com/${{ needs.Check.outputs.githubowner }}/$repoName"
+          Write-Host "Repo URL (Windows): https://github.com/${{ needs.Check.outputs.githubowner }}/$($repoName)w"
+          Write-Host "Repo URL (Linux): https://github.com/${{ needs.Check.outputs.githubowner }}/$($repoName)l"
 
       - name: Run test on Linux
         run: |
           try {
-            . (Join-Path "." "e2eTests/scenarios/${{ matrix.scenario }}/runtest.ps1") -github -linux -githubOwner '${{ needs.Check.outputs.githubowner }}' -repoName ${{ steps.calculateParams.outputs.repoName }} -token '${{ Secrets.E2EPAT }}' -pteTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}' -appSourceTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.appSourceAppRepo }}' -adminCenterApiToken '${{ Secrets.adminCenterApiCredentials }}'
+            . (Join-Path "." "e2eTests/scenarios/${{ matrix.scenario }}/runtest.ps1") -github -linux -githubOwner '${{ needs.Check.outputs.githubowner }}' -repoName '${{ steps.calculateParams.outputs.repoName }}l' -token '${{ Secrets.E2EPAT }}' -pteTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}' -appSourceTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.appSourceAppRepo }}' -adminCenterApiToken '${{ Secrets.adminCenterApiCredentials }}'
           }
           catch {
             Write-Host $_.Exception.Message
@@ -215,7 +216,7 @@ jobs:
       - name: Run test on Windows
         run: |
           try {
-            . (Join-Path "." "e2eTests/scenarios/${{ matrix.scenario }}/runtest.ps1") -github -githubOwner '${{ needs.Check.outputs.githubowner }}' -repoName ${{ steps.calculateParams.outputs.repoName }} -token '${{ Secrets.E2EPAT }}' -pteTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}' -appSourceTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.appSourceAppRepo }}' -adminCenterApiToken '${{ Secrets.adminCenterApiCredentials }}'
+            . (Join-Path "." "e2eTests/scenarios/${{ matrix.scenario }}/runtest.ps1") -github -githubOwner '${{ needs.Check.outputs.githubowner }}' -repoName '${{ steps.calculateParams.outputs.repoName }}w' -token '${{ Secrets.E2EPAT }}' -pteTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.perTenantExtensionRepo }}' -appSourceTemplate '${{ needs.Check.outputs.githubowner }}/${{ needs.SetupRepositories.outputs.appSourceAppRepo }}' -adminCenterApiToken '${{ Secrets.adminCenterApiCredentials }}'
           }
           catch {
             Write-Host $_.Exception.Message

--- a/.github/workflows/E2E.yaml
+++ b/.github/workflows/E2E.yaml
@@ -196,8 +196,8 @@ jobs:
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $reponame = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName())
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "repoName='$repoName'"
-          Write-Host "repoName='$repoName'"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "repoName=$repoName"
+          Write-Host "repoName=$repoName"
           Write-Host "Repo URL (Windows): https://github.com/${{ needs.Check.outputs.githubowner }}/$($repoName)w"
           Write-Host "Repo URL (Linux): https://github.com/${{ needs.Check.outputs.githubowner }}/$($repoName)l"
 

--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -405,7 +405,10 @@ function GetSrcFolder {
     else {
         $path = Join-Path $templateFolder "*/$srcPath"
     }
-    Resolve-Path -Path $path -ErrorAction SilentlyContinue
+    Write-Host "'$path'"
+    $path = Resolve-Path -Path $path -ErrorAction SilentlyContinue
+    Write-Host "'$path'"
+    return $path
 }
 
 function UpdateSettingsFile {

--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -400,14 +400,19 @@ function GetSrcFolder {
                 throw "Unknown repository type"
             }
         }
-        $path = Join-Path $templateFolder "*/Templates/$typePath/$srcPath"
+        $path = Join-Path $templateFolder "*/Templates/$typePath/.github/workflows"
     }
     else {
-        $path = Join-Path $templateFolder "*/$srcPath"
+        $path = Join-Path $templateFolder "*/.github/workflows"
     }
-    Write-Host "'$path'"
+    # Due to this PowerShell bug: https://github.com/PowerShell/PowerShell/issues/6473#issuecomment-375930843
+    # We need to resolve the path of a non-hidden folder (.github/workflows)
+    # and then get the parent folder of the parent folder of that path
     $path = Resolve-Path -Path $path -ErrorAction SilentlyContinue
-    Write-Host "'$path'"
+    if (!$path) {
+        throw "No workflows found in the template repository"
+    }
+    $path = Join-Path -Path (Split-Path -Path (Split-Path -Path $path -Parent) -Parent) -ChildPath $srcPath
     return $path
 }
 

--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -292,13 +292,13 @@ function GetWorkflowContentWithChangesFromSettings {
         ModifyPullRequestHandlerWorkflow -yaml $yaml -repoSettings $repoSettings
     }
 
-    $workflowBlacklist = @('UpdateGitHubGoSystemFiles', 'Troubleshooting')
-    $runnerWhitelist = @('windows-latest', 'ubuntu-latest')
+    $excludedWorkflows = @('UpdateGitHubGoSystemFiles', 'Troubleshooting')
+    $allowedRunners = @('windows-latest', 'ubuntu-latest')
     $modifyRunsOnAndShell = $true
 
-    # Workflows in the blacklist may only run on runners listed in the whitelist
-    if($workflowBlacklist -contains $baseName) {
-        if($runnerWhitelist -notcontains $repoSettings."runs-on") {
+    # Excluded workflows may only run on allowed runners
+    if($excludedWorkflows -contains $baseName) {
+        if($allowedRunners -notcontains $repoSettings."runs-on") {
             $modifyRunsOnAndShell = $false
         }
     }

--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -115,6 +115,9 @@ function ModifyRunsOnAndShell {
     if ($repoSettings.shell -ne "powershell" -and $repoSettings.shell -ne "pwsh") {
         throw "The shell can only be set to powershell or pwsh"
     }
+    if ($repoSettings."runs-on" -eq "ubuntu-latest" -and $repoSettings.shell -eq "powershell") {
+        throw "The shell cannot be set to powershell when runs-on is ubuntu-latest. Use pwsh instead."
+    }
     Write-Host "Setting shell to $($repoSettings.shell)"
     $yaml.ReplaceAll('shell: powershell', "shell: $($repoSettings.shell)")
 }

--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -292,12 +292,12 @@ function GetWorkflowContentWithChangesFromSettings {
         ModifyPullRequestHandlerWorkflow -yaml $yaml -repoSettings $repoSettings
     }
 
-    $excludedWorkflows = @('UpdateGitHubGoSystemFiles', 'Troubleshooting')
+    $criticalWorkflows = @('UpdateGitHubGoSystemFiles', 'Troubleshooting')
     $allowedRunners = @('windows-latest', 'ubuntu-latest')
     $modifyRunsOnAndShell = $true
 
-    # Excluded workflows may only run on allowed runners
-    if($excludedWorkflows -contains $baseName) {
+    # Critical workflows may only run on allowed runners (must always be able to run)
+    if($criticalWorkflows -contains $baseName) {
         if($allowedRunners -notcontains $repoSettings."runs-on") {
             $modifyRunsOnAndShell = $false
         }

--- a/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -274,9 +274,6 @@ function GetWorkflowContentWithChangesFromSettings {
     $baseName = [System.IO.Path]::GetFileNameWithoutExtension($srcFile)
     $yaml = [Yaml]::Load($srcFile)
     $workflowScheduleKey = "$($baseName)Schedule"
-    $workflowBlacklist = @('UpdateGitHubGoSystemFiles', 'Troubleshooting')
-    $runnerWhitelist = @('windows-latest', 'ubuntu-latest')
-    $modifyRunsOnAndShell = $true
 
     # Any workflow (except for the PullRequestHandler and reusable workflows (_*)) can have a RepoSetting called <workflowname>Schedule, which will be used to set the schedule for the workflow
     if ($baseName -ne "PullRequestHandler" -and $baseName -notlike '_*') {
@@ -294,6 +291,10 @@ function GetWorkflowContentWithChangesFromSettings {
     if ($baseName -eq "PullRequestHandler") {
         ModifyPullRequestHandlerWorkflow -yaml $yaml -repoSettings $repoSettings
     }
+
+    $workflowBlacklist = @('UpdateGitHubGoSystemFiles', 'Troubleshooting')
+    $runnerWhitelist = @('windows-latest', 'ubuntu-latest')
+    $modifyRunsOnAndShell = $true
 
     # Workflows in the blacklist may only run on runners listed in the whitelist
     if($workflowBlacklist -contains $baseName) {

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -136,12 +136,10 @@ foreach($checkfile in $checkfiles) {
     $dstFolder = Join-Path $baseFolder $dstPath
     $srcFolder = GetSrcFolder -repoSettings $repoSettings -templateUrl $templateUrl -templateFolder $templateFolder -srcPath $srcPath
     if ($srcFolder) {
-        Write-Host $srcFolder
         Push-Location -Path $srcFolder
         try {
             # Loop through all files in the template repository matching the pattern
-            # Get-ChildItem needs -force to include folders starting with . (e.x. .github / .AL-Go) on Linux
-            Get-ChildItem -Path $srcFolder -Filter $checkfile.pattern -Force | ForEach-Object {
+            Get-ChildItem -Path $srcFolder -Filter $checkfile.pattern | ForEach-Object {
                 # Read the template file and modify it based on the settings
                 # Compare the modified file with the file in the current repository
                 $fileName = $_.Name

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -136,10 +136,11 @@ foreach($checkfile in $checkfiles) {
     $dstFolder = Join-Path $baseFolder $dstPath
     $srcFolder = GetSrcFolder -repoSettings $repoSettings -templateUrl $templateUrl -templateFolder $templateFolder -srcPath $srcPath
     if ($srcFolder) {
+        Write-Host $srcFolder
         Push-Location -Path $srcFolder
         try {
             # Loop through all files in the template repository matching the pattern
-            Get-ChildItem -Path $srcFolder -Filter $checkfile.pattern | ForEach-Object {
+            Get-ChildItem -Path $srcFolder | Where-Object { $_.name -like $checkfile.pattern } | ForEach-Object {
                 # Read the template file and modify it based on the settings
                 # Compare the modified file with the file in the current repository
                 $fileName = $_.Name

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -140,7 +140,8 @@ foreach($checkfile in $checkfiles) {
         Push-Location -Path $srcFolder
         try {
             # Loop through all files in the template repository matching the pattern
-            Get-ChildItem -Path $srcFolder | Where-Object { $_.name -like $checkfile.pattern } | ForEach-Object {
+            # Get-ChildItem needs -force to include folders starting with . (e.x. .github / .AL-Go) on Linux
+            Get-ChildItem -Path $srcFolder -Filter $checkfile.pattern -Force | ForEach-Object {
                 # Read the template file and modify it based on the settings
                 # Compare the modified file with the file in the current repository
                 $fileName = $_.Name

--- a/Actions/CheckForUpdates/CheckForUpdates.ps1
+++ b/Actions/CheckForUpdates/CheckForUpdates.ps1
@@ -129,7 +129,7 @@ if ($repoSettings.useProjectDependencies -and $projects.Count -gt 1) {
 
 # Loop through all folders in CheckFiles and check if there are any files that needs to be updated
 foreach($checkfile in $checkfiles) {
-    Write-Host "Checking $($checkfile.srcPath)\$($checkfile.pattern)"
+    Write-Host "Checking $($checkfile.srcPath)/$($checkfile.pattern)"
     $type = $checkfile.type
     $srcPath = $checkfile.srcPath
     $dstPath = $checkfile.dstPath

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -22,6 +22,11 @@ All authentication context secrets now supports managed identities and federated
 
 In the summary after a Test Run, you now also have the result of performance tests.
 
+### Ubuntu runners for all AL Go workflows
+
+Previously, the workflows "Update AL Go System Files" and "Pull Request Handler" were excluded when changing the two parameters to prevent deadlocks and security issues.
+From now on, a check will only allow changing the parameters of the blacklisted workflows if the `runs-on` parameter is either `windows-latest` or `ubuntu-latest`. Additionally, a check in the function `ModifyRunsOnAndShell` ensures only the value `pwsh` is allowed when using an `ubuntu-latest` runner.
+
 ### New Settings
 
 - `deployTo<environmentName>`: is not really new, but has a new property:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -26,7 +26,7 @@ In the summary after a Test Run, you now also have the result of performance tes
 ### Ubuntu runners for all AL Go workflows
 
 Previously, the workflows "Update AL Go System Files" and "Pull Request Handler" were excluded when changing the two parameters to prevent deadlocks and security issues.
-From now on, a check will only allow changing the parameters of the blacklisted workflows if the `runs-on` parameter is either `windows-latest` or `ubuntu-latest`. Additionally, a check in the function `ModifyRunsOnAndShell` ensures only the value `pwsh` is allowed when using an `ubuntu-latest` runner.
+From now on, a check will only allow changing the parameters of the excluded workflows if the `runs-on` parameter is either `windows-latest` or `ubuntu-latest`. Additionally, only value `pwsh` for `shell` setting is allowed when using an `ubuntu-latest` runner (`runs-on` setting).
 
 ### New Settings
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -23,9 +23,9 @@ All authentication context secrets now supports managed identities and federated
 
 In the summary after a Test Run, you now also have the result of performance tests.
 
-### Support Ubuntu runners for all AL Go workflows
+### Support Ubuntu runners for all AL-Go workflows
 
-Previously, the workflows "Update AL Go System Files" and "TroubleShooting" were hardcoded to always run on `windows-latest` to prevent deadlocks and security issues.
+Previously, the workflows "Update AL-Go System Files" and "TroubleShooting" were hardcoded to always run on `windows-latest` to prevent deadlocks and security issues.
 From now on, `ubuntu-lates` will also be allowed for these mission critical workflows, when changing the `runs-on` setting. Additionally, only the value `pwsh` for `shell` setting is allowed when using `ubuntu-latest` runners.
 
 ### New Settings

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -23,10 +23,10 @@ All authentication context secrets now supports managed identities and federated
 
 In the summary after a Test Run, you now also have the result of performance tests.
 
-### Ubuntu runners for all AL Go workflows
+### Support Ubuntu runners for all AL Go workflows
 
-Previously, the workflows "Update AL Go System Files" and "Pull Request Handler" were excluded when changing the two parameters to prevent deadlocks and security issues.
-From now on, a check will only allow changing the parameters of the excluded workflows if the `runs-on` parameter is either `windows-latest` or `ubuntu-latest`. Additionally, only value `pwsh` for `shell` setting is allowed when using an `ubuntu-latest` runner (`runs-on` setting).
+Previously, the workflows "Update AL Go System Files" and "TroubleShooting" were hardcoded to always run on `windows-latest` to prevent deadlocks and security issues.
+From now on, `ubuntu-lates` will also be allowed for these mission critical workflows, when changing the `runs-on` setting. Additionally, only the value `pwsh` for `shell` setting is allowed when using `ubuntu-latest` runners.
 
 ### New Settings
 

--- a/e2eTests/Test-AL-Go.ps1
+++ b/e2eTests/Test-AL-Go.ps1
@@ -265,8 +265,7 @@ TestNumberOfRuns -expectedNumberOfRuns $runs -repository $repository
 
 Set-Location $prevLocation
 
-# TODO: Before merge uncomment this.
-# RemoveRepository -repository $repository -path $repoPath
+RemoveRepository -repository $repository -path $repoPath
 
 if ($adminCenterApiToken) {
     try {

--- a/e2eTests/Test-AL-Go.ps1
+++ b/e2eTests/Test-AL-Go.ps1
@@ -265,7 +265,8 @@ TestNumberOfRuns -expectedNumberOfRuns $runs -repository $repository
 
 Set-Location $prevLocation
 
-RemoveRepository -repository $repository -path $repoPath
+# TODO: Before merge uncomment this.
+# RemoveRepository -repository $repository -path $repoPath
 
 if ($adminCenterApiToken) {
     try {

--- a/e2eTests/e2eTestHelper.psm1
+++ b/e2eTests/e2eTestHelper.psm1
@@ -461,7 +461,7 @@ function CreateAlGoRepository {
     if ($runson -ne "windows-latest" -or $shell -ne "powershell") {
         $repoSettings | Add-Member -MemberType NoteProperty -Name "runs-on" -Value $runson
         $repoSettings | Add-Member -MemberType NoteProperty -Name "shell" -Value $shell
-        Get-ChildItem -Path '.\.github\workflows\*.yaml' | Where-Object { $_.BaseName -ne "UpdateGitHubGoSystemFiles" -and $_.BaseName -ne "PullRequestHandler" } | ForEach-Object {
+        Get-ChildItem -Path '.\.github\workflows\*.yaml' | ForEach-Object {
             Write-Host $_.FullName
             $content = Get-ContentLF -Path $_.FullName
             $srcPattern = "runs-on: [ windows-latest ]`n"

--- a/e2eTests/scenarios/BuildModes/runtest.ps1
+++ b/e2eTests/scenarios/BuildModes/runtest.ps1
@@ -2,6 +2,7 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'All scenario tests have equal parameter set.')]
 Param(
     [switch] $github,
+    [switch] $linux,
     [string] $githubOwner = $global:E2EgithubOwner,
     [string] $repoName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName()),
     [string] $token = ($Global:SecureE2EPAT | Get-PlainText),
@@ -47,7 +48,7 @@ SetTokenAndRepository -github:$github -githubOwner $githubOwner -token $token -r
 # Create repo
 CreateAlGoRepository `
     -github:$github `
-    -linux `
+    -linux:$linux `
     -template $template `
     -repository $repository `
     -branch $branch `

--- a/e2eTests/scenarios/FederatedCredentials/runtest.ps1
+++ b/e2eTests/scenarios/FederatedCredentials/runtest.ps1
@@ -2,6 +2,7 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'All scenario tests have equal parameter set.')]
 Param(
     [switch] $github,
+    [switch] $linux,
     [string] $githubOwner = $global:E2EgithubOwner,
     [string] $repoName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName()),
     [string] $token = ($Global:SecureE2EPAT | Get-PlainText),
@@ -43,6 +44,11 @@ Write-Host -ForegroundColor Yellow @'
 '@
 
 $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
+
+if ($linux) {
+    Write-Host 'This test is using bcsamples-bingmaps.appsource and should only run once (either Windows or Linux)'
+    exit
+}
 
 Remove-Module e2eTestHelper -ErrorAction SilentlyContinue
 Import-Module (Join-Path $PSScriptRoot "..\..\e2eTestHelper.psm1") -DisableNameChecking

--- a/e2eTests/scenarios/GitHubPackages/runtest.ps1
+++ b/e2eTests/scenarios/GitHubPackages/runtest.ps1
@@ -2,6 +2,7 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'All scenario tests have equal parameter set.')]
 Param(
     [switch] $github,
+    [switch] $linux,
     [string] $githubOwner = $global:E2EgithubOwner,
     [string] $repoName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName()),
     [string] $token = ($Global:SecureE2EPAT | Get-PlainText),
@@ -69,7 +70,7 @@ $githubPackagesContextJson = ($githubPackagesContext | ConvertTo-Json -Compress)
 # Create repository1
 CreateAlGoRepository `
     -github:$github `
-    -linux `
+    -linux:$linux `
     -template $template `
     -repository $repository1 `
     -branch $branch `
@@ -86,7 +87,7 @@ $run1 = RunCICD -repository $repository1 -branch $branch
 
 CreateAlGoRepository `
     -github:$github `
-    -linux `
+    -linux:$linux `
     -template $template `
     -repository $repository2 `
     -branch $branch `
@@ -101,7 +102,7 @@ $repoPath2 = (Get-Location).Path
 
 CreateAlGoRepository `
     -github:$github `
-    -linux `
+    -linux:$linux `
     -template $template `
     -repository $repository `
     -branch $branch `

--- a/e2eTests/scenarios/IncludeDependencies/runtest.ps1
+++ b/e2eTests/scenarios/IncludeDependencies/runtest.ps1
@@ -2,6 +2,7 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'All scenario tests have equal parameter set.')]
 Param(
     [switch] $github,
+    [switch] $linux,
     [string] $githubOwner = $global:E2EgithubOwner,
     [string] $repoName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName()),
     [string] $token = ($Global:SecureE2EPAT | Get-PlainText),
@@ -56,6 +57,7 @@ SetTokenAndRepository -github:$github -githubOwner $githubOwner -token $token -r
 # Create repo
 CreateAlGoRepository `
     -github:$github `
+    -linux:$linux `
     -template $template `
     -repository $repository `
     -branch $branch `

--- a/e2eTests/scenarios/PowerPlatform/runtest.ps1
+++ b/e2eTests/scenarios/PowerPlatform/runtest.ps1
@@ -2,6 +2,7 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'All scenario tests have equal parameter set.')]
 Param(
     [switch] $github,
+    [switch] $linux,
     [string] $githubOwner = $global:E2EgithubOwner,
     [string] $repoName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName()),
     [string] $token = ($Global:SecureE2EPAT | Get-PlainText),
@@ -55,6 +56,7 @@ foreach($sourceRepo in $repositories) {
     # Create repository1
     CreateAlGoRepository `
         -github:$github `
+        -linux:$linux `
         -template "https://github.com/microsoft/$sourceRepo" `
         -repository $repository `
         -branch $branch `

--- a/e2eTests/scenarios/ReleaseBranches/runtest.ps1
+++ b/e2eTests/scenarios/ReleaseBranches/runtest.ps1
@@ -2,6 +2,7 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'All scenario tests have equal parameter set.')]
 Param(
     [switch] $github,
+    [switch] $linux,
     [string] $githubOwner = $global:E2EgithubOwner,
     [string] $repoName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName()),
     [string] $token = ($Global:SecureE2EPAT | Get-PlainText),
@@ -65,7 +66,7 @@ SetTokenAndRepository -github:$github -githubOwner $githubOwner -token $token -r
 # Create repo
 CreateAlGoRepository `
     -github:$github `
-    -linux `
+    -linux:$linux `
     -template $template `
     -repository $repository `
     -branch $branch `

--- a/e2eTests/scenarios/SpecialCharacters/runtest.ps1
+++ b/e2eTests/scenarios/SpecialCharacters/runtest.ps1
@@ -2,6 +2,7 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'All scenario tests have equal parameter set.')]
 Param(
     [switch] $github,
+    [switch] $linux,
     [string] $githubOwner = $global:E2EgithubOwner,
     [string] $repoName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName()),
     [string] $token = ($Global:SecureE2EPAT | Get-PlainText),
@@ -54,6 +55,7 @@ $RepoName = 'Privé'
 # Create repository1
 CreateAlGoRepository `
     -github:$github `
+    -linux:$linux `
     -template $template `
     -repository $repository `
     -branch $branch `

--- a/e2eTests/scenarios/UseProjectDependencies/runtest.ps1
+++ b/e2eTests/scenarios/UseProjectDependencies/runtest.ps1
@@ -2,6 +2,7 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'All scenario tests have equal parameter set.')]
 Param(
     [switch] $github,
+    [switch] $linux,
     [string] $githubOwner = $global:E2EgithubOwner,
     [string] $repoName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName()),
     [string] $token = ($Global:SecureE2EPAT | Get-PlainText),
@@ -57,7 +58,7 @@ SetTokenAndRepository -github:$github -githubOwner $githubOwner -token $token -r
 # Create repo
 CreateAlGoRepository `
     -github:$github `
-    -linux `
+    -linux:$linux `
     -template $template `
     -repository $repository `
     -branch $branch `


### PR DESCRIPTION
This pull request adds a check to allow updating the `runs-on` and `shell` parameters of all workflows. Previously, the workflows "Update AL Go System Files" and "Pull Request Handler" were excluded when changing the two parameters to prevent deadlocks and security issues.
With this change, a check will only allow changing the parameters of the blacklisted workflows if the `runs-on` parameter is either `windows-latest` or `ubuntu-latest`. Additionally, a check in the function `ModifyRunsOnAndShell` ensures only the value `pwsh` is allowed when using an `ubuntu-latest` runner.