### PR TITLE
Remove outdated GitHub Go system files update schedule

### DIFF
--- a/Templates/AppSource App/.github/AL-Go-Settings.json
+++ b/Templates/AppSource App/.github/AL-Go-Settings.json
@@ -20,7 +20,6 @@
     ".schemas/*"
   ],
   "type": "AppSource App",
-  "UpdateGitHubGoSystemFilesSchedule": "0 2 * * 2",
   "useCompilerFolder": true,
   "vsixFile": "latest"
 }

--- a/Templates/Per Tenant Extension/.github/AL-Go-Settings.json
+++ b/Templates/Per Tenant Extension/.github/AL-Go-Settings.json
@@ -20,7 +20,6 @@
     ".schemas/*"
   ],
   "type": "PTE",
-  "UpdateGitHubGoSystemFilesSchedule": "0 2 * * 2",
   "useCompilerFolder": true,
   "vsixFile": "latest"
 }


### PR DESCRIPTION
Eliminate the scheduled update entry for GitHub Go system files in AL-Go settings for both AppSource App and Per Tenant Extension templates.