### PR TITLE
Increase commit substring length for picked commits

### DIFF
--- a/Templates/AppSource App/.github/workflows/UpdateTestBranch.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateTestBranch.yaml
@@ -196,7 +196,7 @@ jobs:
               continue
             fi
             if [[ $(git rev-parse --verify "$commit" 2>/dev/null) ]]; then
-              commit=${commit:0:7}
+              commit=${commit:0:8}
               picked_commits+=("$commit")
               echo "::debug::Commit $commit found."
             else

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateTestBranch.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateTestBranch.yaml
@@ -196,7 +196,7 @@ jobs:
               continue
             fi
             if [[ $(git rev-parse --verify "$commit" 2>/dev/null) ]]; then
-              commit=${commit:0:7}
+              commit=${commit:0:8}
               picked_commits+=("$commit")
               echo "::debug::Commit $commit found."
             else


### PR DESCRIPTION
Update the substring length for commit hashes in the Update Test Branch workflow from 7 to 8 characters to ensure full commit identifiers are captured.