### PR TITLE
Fix regex for capturing full SHA in cherry-picked commits

### DIFF
--- a/Templates/AppSource App/.github/workflows/DocumentMergedCommits.yaml
+++ b/Templates/AppSource App/.github/workflows/DocumentMergedCommits.yaml
@@ -117,7 +117,7 @@ jobs:
             echo "- $commit:"
             commit_comment=$(git show -s --format=%B $commit)
             echo "$commit_comment"
-            commit_sha=$(echo "$commit_comment" | grep -oE '^\s*\(cherry picked from commit .*\)$' | sed 's/^\s*(cherry picked from commit \(.\{7\}\).*/\1/')
+            commit_sha=$(echo "$commit_comment" | grep -oE '^\s*\(cherry picked from commit .*\)$' | sed 's/^\s*(cherry picked from commit \(.\{40\}\).*/\1/')
             if [ -n "$commit_sha" ]; then
               echo "Found original commit $commit_sha."
               picked_commits+=("$commit_sha")

--- a/Templates/Per Tenant Extension/.github/workflows/DocumentMergedCommits.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/DocumentMergedCommits.yaml
@@ -117,7 +117,7 @@ jobs:
             echo "- $commit:"
             commit_comment=$(git show -s --format=%B $commit)
             echo "$commit_comment"
-            commit_sha=$(echo "$commit_comment" | grep -oE '^\s*\(cherry picked from commit .*\)$' | sed 's/^\s*(cherry picked from commit \(.\{7\}\).*/\1/')
+            commit_sha=$(echo "$commit_comment" | grep -oE '^\s*\(cherry picked from commit .*\)$' | sed 's/^\s*(cherry picked from commit \(.\{40\}\).*/\1/')
             if [ -n "$commit_sha" ]; then
               echo "Found original commit $commit_sha."
               picked_commits+=("$commit_sha")


### PR DESCRIPTION
Updated the regex in the Document Merged Commits workflow to correctly extract the full 40-character SHA from commit messages that indicate cherry-picking.