### PR TITLE
Fix cherry-pick loop for array syntax handling

### DIFF
--- a/Templates/AppSource App/.github/workflows/UpdateTestBranch.yaml
+++ b/Templates/AppSource App/.github/workflows/UpdateTestBranch.yaml
@@ -206,7 +206,7 @@ jobs:
           unset IFS
 
           echo "Cherry-picked commits:"
-          for commit in $picked_commits; do
+          for commit in "${picked_commits[@]}"; do
             commit_message=$(git log --format=%s -n 1 $commit)
             echo "$(git log --pretty=format:"- %s (%H)" -n 1 $commit)"
             echo "::debug::$commit"

--- a/Templates/Per Tenant Extension/.github/workflows/UpdateTestBranch.yaml
+++ b/Templates/Per Tenant Extension/.github/workflows/UpdateTestBranch.yaml
@@ -206,7 +206,7 @@ jobs:
           unset IFS
 
           echo "Cherry-picked commits:"
-          for commit in $picked_commits; do
+          for commit in "${picked_commits[@]}"; do
             commit_message=$(git log --format=%s -n 1 $commit)
             echo "$(git log --pretty=format:"- %s (%H)" -n 1 $commit)"
             echo "::debug::$commit"


### PR DESCRIPTION
This change modifies the cherry-pick loop to correctly iterate over the picked commits using array syntax, ensuring proper handling of commit messages.