### PR TITLE
Update BcContainerHelperVersion to latest in templates

### DIFF
--- a/Templates/AppSource App/.github/AL-Go-Settings.json
+++ b/Templates/AppSource App/.github/AL-Go-Settings.json
@@ -14,6 +14,7 @@
   "rulesetFile": "CegekaAT.ruleset.json",
   "runs-on": "ubuntu-latest",
   "skipUpgrade": true,
+  "BcContainerHelperVersion": "latest",
   "templateUrl": "https://github.com/CBS-BC-AT/AL-Go-AppSource@cegeka",
   "templateFiles": [
     ".github/DeployTo*.ps1",

--- a/Templates/Per Tenant Extension/.github/AL-Go-Settings.json
+++ b/Templates/Per Tenant Extension/.github/AL-Go-Settings.json
@@ -14,6 +14,7 @@
   "rulesetFile": "CegekaAT.ruleset.json",
   "runs-on": "ubuntu-latest",
   "skipUpgrade": true,
+  "BcContainerHelperVersion": "latest",
   "templateUrl": "https://github.com/CBS-BC-AT/AL-Go-PTE@cegeka",
   "templateFiles": [
     ".github/DeployTo*.ps1",


### PR DESCRIPTION
Update the BcContainerHelperVersion in the AL-Go-Settings.json files for both AppSource App and Per Tenant Extension templates to ensure improved compatibility and performance.