### PR TITLE
Adjust deployment condition for preview branch

### DIFF
--- a/Internal/Deploy.ps1
+++ b/Internal/Deploy.ps1
@@ -105,7 +105,7 @@ try {
         "appSourceAppRepo" = "$($config.githubOwner)/$($config.appSourceAppRepo)"
     }
 
-    if ($config.branch -eq 'preview' -or $config.githubOwner -ne 'microsoft') {
+    if ($config.branch -eq 'preview') {
         # When deploying to preview, we are NOT going to deploy to a branch in the AL-Go-Actions repository
         # Instead, we are going to have AL-Go-PTE and AL-Go-AppSource point directly to the SHA in AL-Go
         $dstOwnerAndRepo += @{


### PR DESCRIPTION
Update the deployment logic to focus solely on the 'preview' branch, removing the previous condition related to the GitHub owner.